### PR TITLE
Outline & delegation

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -32,10 +32,16 @@
       <button>One</button>
       <button>Time</button>
     </div>
+    <div id="module4" data-ga-track="delegate">
+      <a href="#">Click me</a>
+      <div>
+        <a href="#">Or me</a>
+      </div>
+    </div>
 
 
   <script>
-    GATrack.track([
+    GaTrack.track([
       {
         element: 'span',
         category: 'span',

--- a/package.json
+++ b/package.json
@@ -29,11 +29,11 @@
   "devDependencies": {
     "eslint-config-firstandthird": "3.2.0",
     "eslint-plugin-import": "2.2.0",
-    "phantomjs-prebuilt": "2.1.14",
+    "phantomjs-prebuilt": "2.1.16",
     "scriptkit": "0.2.0",
     "tap-spec": "4.1.1",
     "tape-rollup": "4.6.4",
-    "tape-run": "2.2.0"
+    "tape-run": "3.0.4"
   },
   "eslintConfig": {
     "env": {

--- a/test/ga-track.test.js
+++ b/test/ga-track.test.js
@@ -1,3 +1,11 @@
+/* eslint-disable new-cap */
+if (Element && !Element.prototype.matches) {
+  const proto = Element.prototype;
+  proto.matches = proto.matchesSelector ||
+    proto.mozMatchesSelector || proto.msMatchesSelector ||
+    proto.oMatchesSelector || proto.webkitMatchesSelector;
+}
+
 import GATrack from '../index';
 import test from 'tape-rollup';
 
@@ -48,6 +56,7 @@ test('GATrack plugin exists', assert => {
   assert.equal(typeof GATrack.sendEvent, 'function', 'sendEvent is defined');
   assert.equal(typeof GATrack.track, 'function', 'track is defined');
   assert.equal(typeof GATrack.autotrack, 'function', 'autotrack is defined');
+  assert.equal(typeof window.GAOutlineTracked, 'function', 'outline track is defined');
   assert.end();
 });
 
@@ -189,4 +198,16 @@ test('GATrack.prefix for categories', assert => {
   assert.end();
 
   GATrack.prefix = null;
+});
+
+test('Outline for tracked elements', assert => {
+  setup();
+  const el = document.getElementById('link2');
+
+  assert.equal(el.style.outline, '', 'No outline is set');
+
+  window.GAOutlineTracked();
+
+  assert.equal(el.style.outline, 'red dotted 1px', 'Outline is set');
+  assert.end();
 });


### PR DESCRIPTION
## New features

### Outline

Via `localStorage` with the `GATrackOutline` key or via the global function `GAOutlineTracked`, highlights tracked elements:

![screenshot 2018-02-12 13 19 44](https://user-images.githubusercontent.com/946645/36096691-b129b380-0ff7-11e8-9447-bddaac8050cf.png)

### Event delegation

Now switched to event delegation. We don't need to worry about tracking elements that are appended to the DOM with the right tags. Less CPU overhead too.

### Some notes:

* Needed polyfill for `element.matches`. We really should move away from Phantom into Jest or something similar.
